### PR TITLE
inject proxy vars on specific namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- It's possible to inject proxy vars only for given namespaces
+
 ## [0.0.1] - 2022-04-01
 
 ### Added

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -12,6 +12,12 @@ spec:
         resources:
           kinds:
             - Pod
+{{- if .Proxy.Namespaces }}
+          namespaces:
+          {{- range .Proxy.Namespaces }}
+            - {{ . | quote }}
+          {{- end }}
+{{- end }}
       mutate:
         patchStrategicMerge:
           spec:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -11,6 +11,12 @@ spec:
         resources:
           kinds:
             - Pod
+[[- if .Proxy.Namespaces ]]
+          namespaces:
+          [[- range .Proxy.Namespaces ]]
+            - [[ . | quote ]]
+          [[- end ]]
+[[- end ]]
       mutate:
         patchStrategicMerge:
           spec:


### PR DESCRIPTION
for some reasons it might be helpful to inject the proxy vars only on some dedicated namespaces. For that it's now possible to use the optional namespaces list.

### Checklist

- [x] Update changelog in CHANGELOG.md.
