### PR TITLE
Make noProxy configuration dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Support dynamic policy configuration for proxy.
+
 ## [0.2.3] - 2022-11-30
 
 ## Added

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -18,6 +18,32 @@ spec:
             - {{ . | quote }}
           {{- end }}
 {{- end }}
+      context:
+        - name: kubeadmConfig
+          configMap:
+            name: kubeadm-config
+            namespace: kube-system
+        - name: clusterConfiguration
+          variable:
+            value: {{`"{{ kubeadmConfig.data.ClusterConfiguration | parse_yaml(@) }}"`}}
+        - name: apiEndpoint
+          variable:
+            value: {{`"{{ clusterConfiguration.controlPlaneEndpoint | split(@, ':') | [0] }}"`}}
+        - name: dnsDomain
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.dnsDomain }}"`}}
+        - name: podSubnet
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.podSubnet }}"`}}
+        - name: serviceSubnet
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.serviceSubnet }}"`}}
+        - name: dynamicNoProxy
+          variable:
+            value: {{`"{{apiEndpoint}},{{dnsDomain}},{{podSubnet}},{{serviceSubnet}}"`}}
+        - name: fullNoProxy
+          variable:
+            value: {{ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "{{dynamicNoProxy}}" }}
       mutate:
         patchStrategicMerge:
           spec:
@@ -38,9 +64,9 @@ spec:
                   {{- end }}
                   {{- if $proxy.noProxy }}
                   - name: NO_PROXY
-                    value: {{ join "," $proxy.noProxy }}
+                    value: {{`"{{ fullNoProxy }}"`}}
                   - name: no_proxy
-                    value: {{ join "," $proxy.noProxy }}
+                    value: {{`"{{ fullNoProxy }}"`}}
                   {{- end }}
             initContainers:
               - (name): "*"
@@ -59,9 +85,9 @@ spec:
                   {{- end }}
                   {{- if $proxy.noProxy }}
                   - name: NO_PROXY
-                    value: {{ join "," $proxy.noProxy }}
+                    value: {{`"{{ fullNoProxy }}"`}}
                   - name: no_proxy
-                    value: {{ join "," $proxy.noProxy }}
+                    value: {{`"{{ fullNoProxy }}"`}}
                   {{- end }}
             ephemeralContainers:
               - (name): "*"
@@ -80,8 +106,8 @@ spec:
                   {{- end }}
                   {{- if $proxy.noProxy }}
                   - name: NO_PROXY
-                    value: {{ join "," $proxy.noProxy }}
+                    value: {{`"{{ fullNoProxy }}"`}}
                   - name: no_proxy
-                    value: {{ join "," $proxy.noProxy }}
+                    value: {{`"{{ fullNoProxy }}"`}}
                   {{- end }}
 {{- end }}

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -17,6 +17,32 @@ spec:
             - [[ . | quote ]]
           [[- end ]]
 [[- end ]]
+      context:
+        - name: kubeadmConfig
+          configMap:
+            name: kubeadm-config
+            namespace: kube-system
+        - name: clusterConfiguration
+          variable:
+            value: [[`"[[ kubeadmConfig.data.ClusterConfiguration | parse_yaml(@) ]]"`]]
+        - name: apiEndpoint
+          variable:
+            value: [[`"[[ clusterConfiguration.controlPlaneEndpoint | split(@, ':') | [0] ]]"`]]
+        - name: dnsDomain
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.dnsDomain ]]"`]]
+        - name: podSubnet
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.podSubnet ]]"`]]
+        - name: serviceSubnet
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.serviceSubnet ]]"`]]
+        - name: dynamicNoProxy
+          variable:
+            value: [[`"[[apiEndpoint]],[[dnsDomain]],[[podSubnet]],[[serviceSubnet]]"`]]
+        - name: fullNoProxy
+          variable:
+            value: [[ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "[[dynamicNoProxy]]" ]]
       mutate:
         patchStrategicMerge:
           spec:
@@ -37,9 +63,9 @@ spec:
                   [[- end ]]
                   [[- if $proxy.noProxy ]]
                   - name: NO_PROXY
-                    value: [[ join "," $proxy.noProxy ]]
+                    value: [[`"[[ fullNoProxy ]]"`]]
                   - name: no_proxy
-                    value: [[ join "," $proxy.noProxy ]]
+                    value: [[`"[[ fullNoProxy ]]"`]]
                   [[- end ]]
             initContainers:
               - (name): "*"
@@ -58,9 +84,9 @@ spec:
                   [[- end ]]
                   [[- if $proxy.noProxy ]]
                   - name: NO_PROXY
-                    value: [[ join "," $proxy.noProxy ]]
+                    value: [[`"[[ fullNoProxy ]]"`]]
                   - name: no_proxy
-                    value: [[ join "," $proxy.noProxy ]]
+                    value: [[`"[[ fullNoProxy ]]"`]]
                   [[- end ]]
             ephemeralContainers:
               - (name): "*"
@@ -79,8 +105,8 @@ spec:
                   [[- end ]]
                   [[- if $proxy.noProxy ]]
                   - name: NO_PROXY
-                    value: [[ join "," $proxy.noProxy ]]
+                    value: [[`"[[ fullNoProxy ]]"`]]
                   - name: no_proxy
-                    value: [[ join "," $proxy.noProxy ]]
+                    value: [[`"[[ fullNoProxy ]]"`]]
                   [[- end ]]
 [[- end ]]


### PR DESCRIPTION
Background: https://github.com/giantswarm/roadmap/issues/1424#issuecomment-1321943551

Now, we need to provide cluster-specific noProxy values to this app.
With this PR, the policy will fetch the information from `kubeadm-config` configmap in `kube-system` namespace.

### Checklist

- [x] Update changelog in CHANGELOG.md.
