### PR TITLE
exclude-capi-and-dex-pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Exclude `capi-` pods from the env proxy injection.
+- Exclude `capi-` `dex-k8s-*` pods from the env proxy injection.
 
 ## [0.2.3] - 2022-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Exclude `capi-` pods from the env proxy injection.
+
 ## [0.2.3] - 2022-11-30
 
 ## Added

--- a/helm/kyverno-policies-connectivity/Chart.yaml
+++ b/helm/kyverno-policies-connectivity/Chart.yaml
@@ -6,4 +6,4 @@ name: kyverno-policies-connectivity
 annotations:
   application.giantswarm.io/team: "cabbage"
   config.giantswarm.io/version: 1.x.x
-version: [[.Version]]
+version: v12

--- a/helm/kyverno-policies-connectivity/Chart.yaml
+++ b/helm/kyverno-policies-connectivity/Chart.yaml
@@ -6,4 +6,4 @@ name: kyverno-policies-connectivity
 annotations:
   application.giantswarm.io/team: "cabbage"
   config.giantswarm.io/version: 1.x.x
-version: v12
+version: [[.Version]]

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -8,22 +8,23 @@ metadata:
 spec:
   rules:
     - name: inject-proxy-env-to-containers
+      exclude:
+        any:
+        - resources:
+            kinds:
+            - Pod
+            names:
+            - "capi-*"
       match:
-        resources:
-          kinds:
+        all:
+        - resources:
+            kinds:
             - Pod
 {{- if $proxy.namespaces }}
           namespaces:
           {{- range $proxy.namespaces }}
             - {{ . | quote }}
           {{- end }}
-      exclude:
-        resources:
-          kinds:
-          - Pod
-          names: 
-          - "dex-app*"
-          - "capi-*"
 {{- end }}
       mutate:
         patchStrategicMerge:

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -15,6 +15,7 @@ spec:
             - Pod
             names:
             - "capi-*"
+            - "dex-k8s-*"
       match:
         all:
         - resources:

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -17,6 +17,13 @@ spec:
           {{- range $proxy.namespaces }}
             - {{ . | quote }}
           {{- end }}
+      exclude:
+        resources:
+          kinds:
+          - Pod
+          names: 
+          - "dex-app*"
+          - "capi-*"
 {{- end }}
       mutate:
         patchStrategicMerge:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -16,6 +16,13 @@ spec:
           [[- range $proxy.namespaces ]]
             - [[ . | quote ]]
           [[- end ]]
+      exclude:
+        resources:
+          kinds:
+          - Pod
+          names: 
+          - "dex-app*"
+          - "capi-*"
 [[- end ]]
       mutate:
         patchStrategicMerge:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -7,22 +7,24 @@ metadata:
 spec:
   rules:
     - name: inject-proxy-env-to-containers
+      exclude:
+        any:
+        - resources:
+            kinds:
+            - Pod
+            names:
+            - "capi-*"
+            - "dex-k8s-*"
       match:
-        resources:
-          kinds:
+        all:
+        - resources:
+            kinds:
             - Pod
 [[- if $proxy.namespaces ]]
           namespaces:
           [[- range $proxy.namespaces ]]
             - [[ . | quote ]]
           [[- end ]]
-      exclude:
-        resources:
-          kinds:
-          - Pod
-          names: 
-          - "dex-app*"
-          - "capi-*"
 [[- end ]]
       mutate:
         patchStrategicMerge:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -14,6 +14,7 @@ spec:
             - Pod
             names:
             - "capi-*"
+            - "dex-k8s-*"
       match:
         all:
         - resources:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -14,7 +14,6 @@ spec:
             - Pod
             names:
             - "capi-*"
-            - "dex-k8s-*"
       match:
         all:
         - resources:


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1705

background: capi controllers like capi bootstrap or capi controlplane are connecting to the WC cluster k8s APIs and should not use the proxy for such connections, CAPI itself should not need  connect to outside internet so it does not need proxy

CAPI using a proxy  is an issue when the customer has a restrictive proxy and only allows a predefined list of URLs and its impossible to add each API server  URL to domain list when cluster is created


`dex-k8s` authenticator pods are connecting to the dex ingress and again this should not go thru proxy 