### PR TITLE
Remove validate step from Kyverno policies tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,22 +36,6 @@ jobs:
           command: |
             make verify
 
-  validate:
-    machine:
-      image: ubuntu-2004:202010-01
-    environment:
-      KYVERNO_VERSION: v1.5.0-rc3
-    steps:
-      - checkout
-      - run:
-          name: Download kyverno cli
-          command: |
-            curl -sL https://github.com/kyverno/kyverno/releases/download/${KYVERNO_VERSION}/kyverno-cli_${KYVERNO_VERSION}_linux_x86_64.tar.gz | tar -xz -m kyverno && chmod +x kyverno && sudo mv kyverno /usr/bin
-      - run:
-          name: Validate policies
-          command: |
-            kyverno validate ./policies
-
   test-policies:
     machine:
       image: ubuntu-2004:202010-01
@@ -104,12 +88,6 @@ workflows:
   workflow:
     jobs:
       - verify:
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      - validate:
           # Needed to trigger job also on git tag.
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the `kyverno validate` CI step.
+
 ## [0.3.1] - 2022-12-15
 
 ### Added


### PR DESCRIPTION
Since the `kyverno validate` CLI command was deprecated, we decided to remove the `validate` step from CI. For now, we don't have a direct replacement for `validate`, but we are working on improving Kyverno testing in general.

### Checklist

- [x] Update changelog in CHANGELOG.md.
