### PR TITLE
ignore-pods-with-specific-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add annotation that allows blocking the proxy env injection on specific pod.
+
 ### Changed
 
 - Remove the `kyverno validate` CI step.

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -16,6 +16,11 @@ spec:
             names:
             - "capi-*"
             - "dex-k8s-*"
+        - resources:
+            kinds:
+            - Pod
+            annotations:
+              policies.kyverno.io/inject-proxy-env: block
       match:
         all:
         - resources:

--- a/helm/kyverno-policies-connectivity/templates/Pod.yaml
+++ b/helm/kyverno-policies-connectivity/templates/Pod.yaml
@@ -20,7 +20,7 @@ spec:
             kinds:
             - Pod
             annotations:
-              policies.kyverno.io/inject-proxy-env: block
+              policies.kyverno.io/inject-proxy-env: exclude
       match:
         all:
         - resources:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -19,7 +19,7 @@ spec:
             kinds:
             - Pod
             annotations:
-              policies.kyverno.io/inject-proxy-env: block
+              policies.kyverno.io/inject-proxy-env: exclude
       match:
         all:
         - resources:

--- a/policies/connectivity/Pod.yaml
+++ b/policies/connectivity/Pod.yaml
@@ -15,6 +15,11 @@ spec:
             names:
             - "capi-*"
             - "dex-k8s-*"
+        - resources:
+            kinds:
+            - Pod
+            annotations:
+              policies.kyverno.io/inject-proxy-env: block
       match:
         all:
         - resources:


### PR DESCRIPTION
Ignore injecting pods with specific annotations to allow running pods without proxy in a more controlled way.

This is required by customers running pods on MC. Also, it should supersede the current exclude pattern based on names (that will be removed later)

towards https://github.com/giantswarm/talanx/issues/83