### PR TITLE
add clusterpolicy to sync route53 secret for cert-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ClusterPolicy to sync cert-manager Route53 secret to all `org` namespaces.
+
 ### Changed
 
 - Set `validationFailureAction: Enforce`.

--- a/helm/kyverno-policies-connectivity/templates/CertManagerRoute53SecretSync.yaml
+++ b/helm/kyverno-policies-connectivity/templates/CertManagerRoute53SecretSync.yaml
@@ -1,0 +1,26 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if .Values.certManager.syncSecret }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: sync-cert-manager-route53-secret
+spec:
+  rules:
+  - name: sync-cert-manager-route53-secret
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          names:
+          - "{{ .Values.certManager.targetNamespace }}"
+    generate:
+      apiVersion: v1
+      kind: Secret
+      name: "{{ .Values.cluster.name }}-cert-manager-user-secrets"
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      clone:
+        namespace: "{{ .Values.certManager.sourceNamespace }}"
+        name: "{{ .Values.cluster.name }}-cert-manager-user-secrets"
+{{- end }}

--- a/helm/kyverno-policies-connectivity/templates/CertManagerRoute53SecretSync.yaml
+++ b/helm/kyverno-policies-connectivity/templates/CertManagerRoute53SecretSync.yaml
@@ -18,7 +18,7 @@ spec:
       apiVersion: v1
       kind: Secret
       name: "{{ .Values.cluster.name }}-cert-manager-user-secrets"
-      namespace: "{{request.object.metadata.name}}"
+      namespace: {{`"{{request.object.metadata.name}}"`}}
       synchronize: true
       clone:
         namespace: "{{ .Values.certManager.sourceNamespace }}"

--- a/helm/kyverno-policies-connectivity/values.schema.json
+++ b/helm/kyverno-policies-connectivity/values.schema.json
@@ -2,10 +2,36 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "certManager": {
+            "title": "CertManager",
+            "type": "object",
+            "properties": {
+                "sourceNamespace": {
+                    "description": "Namespace containing source secret to sync to other namespaces",
+                    "title": "SourceNamespace",
+                    "type": "string"
+                },
+                "syncSecret": {
+                    "description": "Should the policy to sync the Route53 secret be enabled?",
+                    "title": "SyncSecret",
+                    "type": "boolean"
+                },
+                "targetNamespace": {
+                    "description": "Destinatinon namespace to sync the secret to",
+                    "title": "TargetNamespace",
+                    "type": "string"
+                }
+            }
+        },
         "cluster": {
             "title": "Cluster",
             "type": "object",
             "properties": {
+                "name": {
+                    "description": "The name of the installation",
+                    "title": "Name",
+                    "type": "string"
+                },
                 "proxy": {
                     "title": "Proxy related settings",
                     "type": "object",

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -1,7 +1,13 @@
+certManager:
+  sourceNamespace: ""
+  syncSecret: false
+  targetNamespace: "org-*"
+
 proxy:
   enabled: false
 
 cluster:
+  name: ""
   proxy:
     http: ""
     https: ""

--- a/policies/connectivity/CertManagerRoute53SecretSync.yaml
+++ b/policies/connectivity/CertManagerRoute53SecretSync.yaml
@@ -17,7 +17,7 @@ spec:
       apiVersion: v1
       kind: Secret
       name: "[[ .Values.cluster.name ]]-cert-manager-user-secrets"
-      namespace: "[[request.object.metadata.name]]"
+      namespace: [[`"[[request.object.metadata.name]]"`]]
       synchronize: true
       clone:
         namespace: "[[ .Values.certManager.sourceNamespace ]]"

--- a/policies/connectivity/CertManagerRoute53SecretSync.yaml
+++ b/policies/connectivity/CertManagerRoute53SecretSync.yaml
@@ -1,0 +1,25 @@
+[[- if .Values.certManager.syncSecret ]]
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: sync-cert-manager-route53-secret
+spec:
+  rules:
+  - name: sync-cert-manager-route53-secret
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          names:
+          - "[[ .Values.certManager.targetNamespace ]]"
+    generate:
+      apiVersion: v1
+      kind: Secret
+      name: "[[ .Values.cluster.name ]]-cert-manager-user-secrets"
+      namespace: "[[request.object.metadata.name]]"
+      synchronize: true
+      clone:
+        namespace: "[[ .Values.certManager.sourceNamespace ]]"
+        name: "[[ .Values.cluster.name ]]-cert-manager-user-secrets"
+[[- end ]]


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27296

This PR:

- adds a clusterpolicy to sync secrets from one namespace to a target namespace (or namespaces when using a regex). Configured via [this PR](https://github.com/giantswarm/mc-bootstrap/pull/627)

### Checklist

- [x] Update changelog in CHANGELOG.md.
