### PR TITLE
Fix missing apiVersion in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix missing `apiVersion` in manifest for `check-wc-cp-ip-clusters` policy.
+
 ## [0.5.2] - 2023-08-04
 
 ### Added

--- a/helm/kyverno-policies-connectivity/templates/wc-ip/WorkloadClusterIp.yaml
+++ b/helm/kyverno-policies-connectivity/templates/wc-ip/WorkloadClusterIp.yaml
@@ -1,5 +1,5 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if eq (include "isWcIpCheckEnabled" $) "true" -}}
+{{- if eq (include "isWcIpCheckEnabled" $) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/helm/kyverno-policies-connectivity/templates/wc-ip/WorkloadClusterIpJob.yaml
+++ b/helm/kyverno-policies-connectivity/templates/wc-ip/WorkloadClusterIpJob.yaml
@@ -1,5 +1,5 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if eq (include "isWcIpCheckEnabled" $) "true" -}}
+{{- if eq (include "isWcIpCheckEnabled" $) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/policies/connectivity/wc-ip/WorkloadClusterIp.yaml
+++ b/policies/connectivity/wc-ip/WorkloadClusterIp.yaml
@@ -1,4 +1,4 @@
-[[- if eq (include "isWcIpCheckEnabled" $) "true" -]]
+[[- if eq (include "isWcIpCheckEnabled" $) "true" ]]
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policies/connectivity/wc-ip/WorkloadClusterIpJob.yaml
+++ b/policies/connectivity/wc-ip/WorkloadClusterIpJob.yaml
@@ -1,4 +1,4 @@
-[[- if eq (include "isWcIpCheckEnabled" $) "true" -]]
+[[- if eq (include "isWcIpCheckEnabled" $) "true" ]]
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The first line containing the apiVersion of the list of yamls was appended to the previous line -> malformed yaml manifest


the app is not installable if this policy is enabled:
```
k describe app kyverno-policies-connectivity -n giantswarm | grep -A1 Reason:                                                                                                                         ○ gmc-admin@gmc
    Reason:         resource mapping not found for name: "kyverno-policies-connectivity-check-wc-cp-ip" namespace: "" from "": no matches for kind "ClusterPolicy" in version ""
ensure CRDs are installed first
```

before:
```yaml
helm template . -f ~/workspace/config/installations/gmc/apps/kyverno-policies-connectivity/configmap-values.yaml.patch | grep -A3 "apiVersion: kyverno.io/v1"
# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLYapiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: release-name-check-wc-cp-ip
```

after (w/ this change):

```yaml
helm template . -f ~/workspace/config/installations/gmc/apps/kyverno-policies-connectivity/configmap-values.yaml.patch | grep -A3 "apiVersion: kyverno.io/v1"
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: release-name-check-wc-cp-ip
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
