### PR TITLE
inject proxy url to prometheus-buddy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Inject proxy url to the `mimir-to-grafana-cloud` prometheus CR.
+- Inject proxy url to the `mimir-to-grafana-cloud` Prometheus CR.
 
 ## [0.5.4] - 2024-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove unused tests under helm directory.
 
+### Changed
+
+- Inject proxy url to the `mimir-to-grafana-cloud` prometheus CR.
+
 ## [0.5.4] - 2024-01-09
 
 ### Changed

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -9,14 +9,14 @@ spec:
   validationFailureAction: Enforce
   rules:
     {{- if .Values.mimir.enabled }}
-    - name: inject-proxy-env-to-prometheus-buddy
+    - name: inject-proxy-env-to-prometheus-remotewrite
       match:
         all:
         - resources:
             kinds:
-            - monitoring.coreos.com/v1/Prometheus
-            names:
-            - {{ .Values.mimir.prometheus.name }}
+            - monitoring.coreos.com/*/Prometheus
+          namespaces:
+          - mimir
       context:
         - name: kubeadmConfig
           configMap:
@@ -45,7 +45,7 @@ spec:
             value: {{ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "{{dynamicNoProxy}}" }}
       mutate:
         patchStrategicMerge:
-          spec: 
+          spec:
             remoteWrite:
               - (name): "*"
                 {{- if $proxy.http }}

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -51,9 +51,6 @@ spec:
                 {{- if $proxy.http }}
                 proxyUrl: {{ $proxy.http }}
                 {{- end }}
-                {{- if $proxy.https }}
-                proxyUrl: {{ $proxy.https }}
-                {{- end }}
     {{- end }}
     - name: inject-proxy-env-to-containers
       exclude:

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -16,7 +16,7 @@ spec:
             kinds:
             - monitoring.coreos.com/v1/Prometheus
             names:
-            - {{ .Valeus.mimir.prometheusBuddyName }}
+            - {{ .Valeus.mimir.prometheus.name }}
       context:
         - name: kubeadmConfig
           configMap:

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -8,6 +8,53 @@ metadata:
 spec:
   validationFailureAction: Enforce
   rules:
+    {{- if .Values.mimir.enabled }}
+    - name: inject-proxy-env-to-prometheus-buddy
+      match:
+        all:
+        - resources:
+            kinds:
+            - monitoring.coreos.com/v1/Prometheus
+            names:
+            - {{ .Valeus.mimir.prometheusBuddyName }}
+      context:
+        - name: kubeadmConfig
+          configMap:
+            name: kubeadm-config
+            namespace: kube-system
+        - name: clusterConfiguration
+          variable:
+            value: {{`"{{ kubeadmConfig.data.ClusterConfiguration | parse_yaml(@) }}"`}}
+        - name: apiEndpoint
+          variable:
+            value: {{`"{{ clusterConfiguration.controlPlaneEndpoint | split(@, ':') | [0] }}"`}}
+        - name: dnsDomain
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.dnsDomain }}"`}}
+        - name: podSubnet
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.podSubnet }}"`}}
+        - name: serviceSubnet
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.serviceSubnet }}"`}}
+        - name: dynamicNoProxy
+          variable:
+            value: {{`"{{apiEndpoint}},{{dnsDomain}},{{podSubnet}},{{serviceSubnet}}"`}}
+        - name: fullNoProxy
+          variable:
+            value: {{ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "{{dynamicNoProxy}}" }}
+      mutate:
+        patchStrategicMerge:
+          spec: 
+            remoteWrite:
+              - (name): "*"
+                {{- if $proxy.http }}
+                proxyUrl: {{ $proxy.http }}
+                {{- end }}
+                {{- if $proxy.https }}
+                proxyUrl: {{ $proxy.https }}
+                {{- end }}
+    {{- end }}
     - name: inject-proxy-env-to-containers
       exclude:
         any:

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -16,7 +16,7 @@ spec:
             kinds:
             - monitoring.coreos.com/v1/Prometheus
             names:
-            - {{ .Valeus.mimir.prometheus.name }}
+            - {{ .Values.mimir.prometheus.name }}
       context:
         - name: kubeadmConfig
           configMap:

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -8,7 +8,9 @@ proxy:
 
 mimir:
   enabled: false
-  prometheusBuddyName: mimir-to-grafana-cloud
+  prometheus: 
+    name: mimir-to-grafana-cloud
+    namespace: mimir
 
 cluster:
   name: ""

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -8,9 +8,8 @@ proxy:
 
 mimir:
   enabled: false
-  prometheus: 
+  prometheus:
     name: mimir-to-grafana-cloud
-    namespace: mimir
 
 cluster:
   name: ""

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -6,6 +6,10 @@ certManager:
 proxy:
   enabled: false
 
+mimir:
+  enabled: false
+  prometheusBuddyName: mimir-to-grafana-cloud
+
 cluster:
   name: ""
   proxy:

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -8,8 +8,6 @@ proxy:
 
 mimir:
   enabled: false
-  prometheus:
-    name: mimir-to-grafana-cloud
 
 cluster:
   name: ""

--- a/policies/connectivity/proxy/PodController.yaml
+++ b/policies/connectivity/proxy/PodController.yaml
@@ -15,7 +15,7 @@ spec:
             kinds:
             - monitoring.coreos.com/v1/Prometheus
             names:
-            - [[ .Valeus.mimir.prometheus.name ]]
+            - [[ .Values.mimir.prometheus.name ]]
       context:
         - name: kubeadmConfig
           configMap:

--- a/policies/connectivity/proxy/PodController.yaml
+++ b/policies/connectivity/proxy/PodController.yaml
@@ -50,9 +50,6 @@ spec:
                 [[- if $proxy.http ]]
                 proxyUrl: [[ $proxy.http ]]
                 [[- end ]]
-                [[- if $proxy.https ]]
-                proxyUrl: [[ $proxy.https ]]
-                [[- end ]]
     [[- end ]]
     - name: inject-proxy-env-to-containers
       exclude:

--- a/policies/connectivity/proxy/PodController.yaml
+++ b/policies/connectivity/proxy/PodController.yaml
@@ -8,14 +8,14 @@ spec:
   validationFailureAction: Enforce
   rules:
     [[- if .Values.mimir.enabled ]]
-    - name: inject-proxy-env-to-prometheus-buddy
+    - name: inject-proxy-env-to-prometheus-remotewrite
       match:
         all:
         - resources:
             kinds:
-            - monitoring.coreos.com/v1/Prometheus
-            names:
-            - [[ .Values.mimir.prometheus.name ]]
+            - monitoring.coreos.com/*/Prometheus
+          namespaces:
+          - mimir
       context:
         - name: kubeadmConfig
           configMap:
@@ -44,7 +44,7 @@ spec:
             value: [[ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "[[dynamicNoProxy]]" ]]
       mutate:
         patchStrategicMerge:
-          spec: 
+          spec:
             remoteWrite:
               - (name): "*"
                 [[- if $proxy.http ]]

--- a/policies/connectivity/proxy/PodController.yaml
+++ b/policies/connectivity/proxy/PodController.yaml
@@ -7,6 +7,53 @@ metadata:
 spec:
   validationFailureAction: Enforce
   rules:
+    [[- if .Values.mimir.enabled ]]
+    - name: inject-proxy-env-to-prometheus-buddy
+      match:
+        all:
+        - resources:
+            kinds:
+            - monitoring.coreos.com/v1/Prometheus
+            names:
+            - [[ .Valeus.mimir.prometheus.name ]]
+      context:
+        - name: kubeadmConfig
+          configMap:
+            name: kubeadm-config
+            namespace: kube-system
+        - name: clusterConfiguration
+          variable:
+            value: [[`"[[ kubeadmConfig.data.ClusterConfiguration | parse_yaml(@) ]]"`]]
+        - name: apiEndpoint
+          variable:
+            value: [[`"[[ clusterConfiguration.controlPlaneEndpoint | split(@, ':') | [0] ]]"`]]
+        - name: dnsDomain
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.dnsDomain ]]"`]]
+        - name: podSubnet
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.podSubnet ]]"`]]
+        - name: serviceSubnet
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.serviceSubnet ]]"`]]
+        - name: dynamicNoProxy
+          variable:
+            value: [[`"[[apiEndpoint]],[[dnsDomain]],[[podSubnet]],[[serviceSubnet]]"`]]
+        - name: fullNoProxy
+          variable:
+            value: [[ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "[[dynamicNoProxy]]" ]]
+      mutate:
+        patchStrategicMerge:
+          spec: 
+            remoteWrite:
+              - (name): "*"
+                [[- if $proxy.http ]]
+                proxyUrl: [[ $proxy.http ]]
+                [[- end ]]
+                [[- if $proxy.https ]]
+                proxyUrl: [[ $proxy.https ]]
+                [[- end ]]
+    [[- end ]]
     - name: inject-proxy-env-to-containers
       exclude:
         any:


### PR DESCRIPTION
This PR enables the `inject-proxy-env` ClusterPolicy to inject the proxyUrl directly into the "prometheus-buddy" Prometheus CR. This is needed on `goat` for this prometheus to be able to send mimir's metrics to grafana cloud.

### Checklist

- [x] Update changelog in CHANGELOG.md.
