### PR TITLE
Increase WCIP Job SecurityContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update kubectl container image to version v1.26.0 for WorkloadCluster Ip Job
+- Increase pod and container SecurityContext settings for WorkloadCluster Ip Job
+- Execute `kubectl apply` with `--server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts` flags in WorkloadCluster Ip Job
+
 ### Removed
 
 - Remove unused tests under helm directory.

--- a/helm/kyverno-policies-connectivity/templates/wc-ip/WorkloadClusterIpJob.yaml
+++ b/helm/kyverno-policies-connectivity/templates/wc-ip/WorkloadClusterIpJob.yaml
@@ -92,11 +92,25 @@ spec:
       restartPolicy: Never
       serviceAccountName: "{{ .Release.Name }}-read-write-configmap"
       securityContext:
+        runAsNonRoot: true
         runAsUser: {{ .Values.wcIpCheck.installJob.securityContext.runAsUser }}
         runAsGroup: {{ .Values.wcIpCheck.installJob.securityContext.runAsGroup }}
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: pre-install-job
           image: "{{ .Values.wcIpCheck.installJob.kubectlImage.registry }}/{{ .Values.wcIpCheck.installJob.kubectlImage.name }}:{{ .Values.wcIpCheck.installJob.kubectlImage.tag }}"
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsUser: {{ .Values.wcIpCheck.installJob.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.wcIpCheck.installJob.securityContext.runAsGroup }}
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - "/bin/bash"
             - "-xec"
@@ -141,11 +155,13 @@ spec:
               done
               {{- end }}
               {{- end }}
-              
+
               set +x
               echo -e "\n\nApplying following configmap:\n-----------------------------"
               cat /tmp/cm.yaml
-              kubectl apply -f /tmp/cm.yaml
+              # piping stderr to stdout means kubectl's errors are surfaced
+              # in the pod's logs.
+              kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /tmp/cm.yaml 2>&1
 
           resources:
             requests:

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -40,4 +40,4 @@ wcIpCheck:
     kubectlImage:
       registry: gsoci.azurecr.io
       name: giantswarm/kubectl
-      tag: 1.23.5
+      tag: 1.26.0


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31211

This PR:

- Updates kubectl container image to version v1.26.0 for WorkloadCluster Ip Job
- Increases pod and container SecurityContext settings for WorkloadCluster Ip Job
- Changes execution of `kubectl apply` with `--server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts` flags in WorkloadCluster Ip Job

### Checklist

- [x] Update changelog in CHANGELOG.md.
