### PR TITLE
Add dnsDomainRoot to allow .cluster.local. in proxied environements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add dnsDomainDot to fix an issue with applications using .cluster.local.
+- Add dnsDomainRoot to fix an issue with applications using .cluster.local.
 
 ## [0.6.2] - 2024-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add dnsDomainDot to fix an issue with applications using .cluster.local.
+
 ## [0.6.2] - 2024-10-31
 
 ### Changed

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -57,6 +57,9 @@ spec:
         - name: dnsDomain
           variable:
             value: {{`"{{ clusterConfiguration.networking.dnsDomain }}"`}}
+        - name: dnsDomainDot
+          variable:
+            value: {{`"{{ clusterConfiguration.networking.dnsDomain }}."`}}
         - name: podSubnet
           variable:
             value: {{`"{{ clusterConfiguration.networking.podSubnet }}"`}}
@@ -65,7 +68,7 @@ spec:
             value: {{`"{{ clusterConfiguration.networking.serviceSubnet }}"`}}
         - name: dynamicNoProxy
           variable:
-            value: {{`"{{apiEndpoint}},{{dnsDomain}},{{podSubnet}},{{serviceSubnet}}"`}}
+            value: {{`"{{apiEndpoint}},{{dnsDomain}},{{dnsDomainDot}},{{podSubnet}},{{serviceSubnet}}"`}}
         - name: fullNoProxy
           variable:
             value: {{ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "{{dynamicNoProxy}}" }}

--- a/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
+++ b/helm/kyverno-policies-connectivity/templates/proxy/PodController.yaml
@@ -57,7 +57,7 @@ spec:
         - name: dnsDomain
           variable:
             value: {{`"{{ clusterConfiguration.networking.dnsDomain }}"`}}
-        - name: dnsDomainDot
+        - name: dnsDomainRoot
           variable:
             value: {{`"{{ clusterConfiguration.networking.dnsDomain }}."`}}
         - name: podSubnet
@@ -68,7 +68,7 @@ spec:
             value: {{`"{{ clusterConfiguration.networking.serviceSubnet }}"`}}
         - name: dynamicNoProxy
           variable:
-            value: {{`"{{apiEndpoint}},{{dnsDomain}},{{dnsDomainDot}},{{podSubnet}},{{serviceSubnet}}"`}}
+            value: {{`"{{apiEndpoint}},{{dnsDomain}},{{dnsDomainRoot}},{{podSubnet}},{{serviceSubnet}}"`}}
         - name: fullNoProxy
           variable:
             value: {{ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "{{dynamicNoProxy}}" }}

--- a/policies/connectivity/proxy/PodController.yaml
+++ b/policies/connectivity/proxy/PodController.yaml
@@ -56,6 +56,9 @@ spec:
         - name: dnsDomain
           variable:
             value: [[`"[[ clusterConfiguration.networking.dnsDomain ]]"`]]
+        - name: dnsDomainDot
+          variable:
+            value: [[`"[[ clusterConfiguration.networking.dnsDomain ]]."`]]
         - name: podSubnet
           variable:
             value: [[`"[[ clusterConfiguration.networking.podSubnet ]]"`]]
@@ -64,7 +67,7 @@ spec:
             value: [[`"[[ clusterConfiguration.networking.serviceSubnet ]]"`]]
         - name: dynamicNoProxy
           variable:
-            value: [[`"[[apiEndpoint]],[[dnsDomain]],[[podSubnet]],[[serviceSubnet]]"`]]
+            value: [[`"[[apiEndpoint]],[[dnsDomain]],[[dnsDomainDot]],[[podSubnet]],[[serviceSubnet]]"`]]
         - name: fullNoProxy
           variable:
             value: [[ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "[[dynamicNoProxy]]" ]]

--- a/policies/connectivity/proxy/PodController.yaml
+++ b/policies/connectivity/proxy/PodController.yaml
@@ -56,7 +56,7 @@ spec:
         - name: dnsDomain
           variable:
             value: [[`"[[ clusterConfiguration.networking.dnsDomain ]]"`]]
-        - name: dnsDomainDot
+        - name: dnsDomainRoot
           variable:
             value: [[`"[[ clusterConfiguration.networking.dnsDomain ]]."`]]
         - name: podSubnet
@@ -67,7 +67,7 @@ spec:
             value: [[`"[[ clusterConfiguration.networking.serviceSubnet ]]"`]]
         - name: dynamicNoProxy
           variable:
-            value: [[`"[[apiEndpoint]],[[dnsDomain]],[[dnsDomainDot]],[[podSubnet]],[[serviceSubnet]]"`]]
+            value: [[`"[[apiEndpoint]],[[dnsDomain]],[[dnsDomainRoot]],[[podSubnet]],[[serviceSubnet]]"`]]
         - name: fullNoProxy
           variable:
             value: [[ printf "\"%s,%s,%s\"" $proxy.noProxy "svc,127.0.0.1,localhost" "[[dynamicNoProxy]]" ]]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32110

This PR adds `dnsDomainRoot` which allows to set the dns domain to `.cluster.local.` in proxied environments.

I would need some guidance on how I can test this change.


### Checklist

- [x] Update changelog in CHANGELOG.md.