### PR TITLE
Add policy to generate public CA ConfigMap from CAPI cluster CA Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `generate-cluster-ca-public-configmap` Kyverno policy that generates a `<cluster-name>-ca-public` ConfigMap from CAPI cluster CA Secrets, containing only the public CA certificate. Gated by `clusterCaPublic.enabled` value.
+
 ## [0.10.1] - 2026-01-06
 
 ### Fixed

--- a/helm/kyverno-policies-connectivity/templates/ClusterCaPublicConfigMap.yaml
+++ b/helm/kyverno-policies-connectivity/templates/ClusterCaPublicConfigMap.yaml
@@ -1,0 +1,71 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if .Values.clusterCaPublic.enabled }}
+# Grant kyverno-background-controller permission to manage ConfigMaps
+# so it can generate and sync the CA public ConfigMap.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Release.Name }}-generate-cluster-ca-public-configmap"
+  annotations:
+    {{- include "preinstallHookAnnotations" $ | nindent 4 }}
+    "helm.sh/hook-weight": "-2"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "update", "get", "delete", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-generate-cluster-ca-public-configmap"
+  annotations:
+    {{- include "preinstallHookAnnotations" $ | nindent 4 }}
+    "helm.sh/hook-weight": "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-generate-cluster-ca-public-configmap"
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-cluster-ca-public-configmap
+spec:
+  rules:
+  - name: generate-cluster-ca-public-configmap
+    match:
+      any:
+      - resources:
+          kinds:
+          - Secret
+          names:
+          - "*-ca"
+          selector:
+            matchExpressions:
+            - key: cluster.x-k8s.io/cluster-name
+              operator: Exists
+    context:
+    - name: clusterName
+      variable:
+        jmesPath: 'request.object.metadata.labels."cluster.x-k8s.io/cluster-name"'
+    - name: caCert
+      variable:
+        jmesPath: 'base64_decode(request.object.data."tls.crt")'
+    generate:
+      apiVersion: v1
+      kind: ConfigMap
+      name: "{{ `{{` }}clusterName{{ `}}` }}-ca-public"
+      namespace: "{{ `{{` }}request.object.metadata.namespace{{ `}}` }}"
+      synchronize: true
+      data:
+        metadata:
+          labels:
+            cluster.x-k8s.io/cluster-name: "{{ `{{` }}clusterName{{ `}}` }}"
+            app.giantswarm.io/managed-by: kyverno
+        data:
+          ca.crt: "{{ `{{` }}caCert{{ `}}` }}"
+{{- end }}

--- a/helm/kyverno-policies-connectivity/values.schema.json
+++ b/helm/kyverno-policies-connectivity/values.schema.json
@@ -23,6 +23,17 @@
                 }
             }
         },
+        "clusterCaPublic": {
+            "title": "ClusterCaPublic",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Generate a public ConfigMap from CAPI cluster CA Secrets containing only the CA certificate",
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            }
+        },
         "cluster": {
             "title": "Cluster",
             "type": "object",

--- a/helm/kyverno-policies-connectivity/values.yaml
+++ b/helm/kyverno-policies-connectivity/values.yaml
@@ -3,6 +3,9 @@ certManager:
   syncSecret: false
   targetNamespace: "org-*"
 
+clusterCaPublic:
+  enabled: false
+
 proxy:
   enabled: false
 

--- a/policies/connectivity/ClusterCaPublicConfigMap.yaml
+++ b/policies/connectivity/ClusterCaPublicConfigMap.yaml
@@ -1,0 +1,70 @@
+[[- if .Values.clusterCaPublic.enabled ]]
+# Grant kyverno-background-controller permission to manage ConfigMaps
+# so it can generate and sync the CA public ConfigMap.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "[[ .Release.Name ]]-generate-cluster-ca-public-configmap"
+  annotations:
+    [[- include "preinstallHookAnnotations" $ | nindent 4 ]]
+    "helm.sh/hook-weight": "-2"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "update", "get", "delete", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "[[ .Release.Name ]]-generate-cluster-ca-public-configmap"
+  annotations:
+    [[- include "preinstallHookAnnotations" $ | nindent 4 ]]
+    "helm.sh/hook-weight": "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "[[ .Release.Name ]]-generate-cluster-ca-public-configmap"
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-cluster-ca-public-configmap
+spec:
+  rules:
+  - name: generate-cluster-ca-public-configmap
+    match:
+      any:
+      - resources:
+          kinds:
+          - Secret
+          names:
+          - "*-ca"
+          selector:
+            matchExpressions:
+            - key: cluster.x-k8s.io/cluster-name
+              operator: Exists
+    context:
+    - name: clusterName
+      variable:
+        jmesPath: 'request.object.metadata.labels."cluster.x-k8s.io/cluster-name"'
+    - name: caCert
+      variable:
+        jmesPath: 'base64_decode(request.object.data."tls.crt")'
+    generate:
+      apiVersion: v1
+      kind: ConfigMap
+      name: "{{clusterName}}-ca-public"
+      namespace: "{{request.object.metadata.namespace}}"
+      synchronize: true
+      data:
+        metadata:
+          labels:
+            cluster.x-k8s.io/cluster-name: "{{clusterName}}"
+            app.giantswarm.io/managed-by: kyverno
+        data:
+          ca.crt: "{{caCert}}"
+[[- end ]]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35444

## Summary

- Adds a new `generate-cluster-ca-public-configmap` Kyverno policy that watches for CAPI cluster CA Secrets (`*-ca`) and generates a `<cluster-name>-ca-public` ConfigMap containing only the public CA certificate (`tls.crt`).
- The generated ConfigMap is kept in sync with the source Secret via `synchronize: true`.
- Gated by `clusterCaPublic.enabled` (disabled by default).

## Context

This is part of an effort to remove the `cluster-values` ConfigMap from `cluster-apps-operator`. Currently, apps like `athena` and `dex-app` receive the cluster CA via `cluster-values`. With this policy, they can instead reference the `<cluster-name>-ca-public` ConfigMap directly (e.g., via Flux HelmRelease `valuesFrom`), without exposing the private key.
